### PR TITLE
Pass request headers to Headers constructor in changeRegion action

### DIFF
--- a/apps/storefront/app/routes/api.region.ts
+++ b/apps/storefront/app/routes/api.region.ts
@@ -22,7 +22,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     await retrieveRegion(regionId);
 
-    const headers = new Headers();
+    const headers = new Headers(request.headers);
 
     await setSelectedRegionId(headers, regionId);
 

--- a/apps/storefront/app/routes/api.region.ts
+++ b/apps/storefront/app/routes/api.region.ts
@@ -22,11 +22,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     await retrieveRegion(regionId);
 
-    const headers = new Headers(request.headers);
+    const headers = new Headers();
 
     await setSelectedRegionId(headers, regionId);
 
-    const cartId = await getCartId(headers);
+    const cartId = await getCartId(request.headers);
 
     if (cartId) await updateCart(request, { region_id: regionId });
 


### PR DESCRIPTION
The changeRegion action now correctly passes request headers to the Headers constructor, ensuring that the headers are utilized in subsequent operations. fixes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of request headers to ensure existing headers are preserved when selecting a region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->