### PR TITLE
Fix Railway Docker builds on Node 26

### DIFF
--- a/apps/medusa/Dockerfile
+++ b/apps/medusa/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:26-alpine AS base
 
 RUN apk update && apk add --no-cache libc6-compat
+RUN npm install -g corepack && corepack enable && corepack prepare yarn@4.9.1 --activate
 
 WORKDIR /app
 
@@ -41,4 +42,4 @@ WORKDIR /app/server
 
 ENV PORT=80
 
-CMD ["yarn", "start:prod"]
+CMD ["sh", "-c", "yarn migrate:prod && yarn start:prod"]

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:26-alpine AS base
 
 RUN apk update && apk add --no-cache libc6-compat
+RUN npm install -g corepack && corepack enable && corepack prepare yarn@4.9.1 --activate
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install and activate Corepack/Yarn 4.9.1 in both Node 26 Docker base stages
- run Medusa production migrations before starting the container so existing Railway data gets Medusa's tax-region provider migration

## Verification
- docker build -f apps/storefront/Dockerfile .
- docker build -f apps/medusa/Dockerfile .

## Notes
Railway storefront build failed at `RUN yarn install` with `/bin/sh: yarn: not found` after moving to `node:26-alpine`. The Node 26 Alpine image also lacks `corepack`, so the Dockerfiles install Corepack with npm before activating the repo-pinned Yarn version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container setup to use Corepack with a pinned Yarn 4.9.1 version for more consistent builds.
  * Adjusted the production startup flow so database migrations run automatically before the app launches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->