### PR TITLE
Fix Medusa Zod dependency resolution

### DIFF
--- a/apps/medusa/package.json
+++ b/apps/medusa/package.json
@@ -62,6 +62,9 @@
     "typescript": "^5.7.3",
     "yalc": "^1.0.0-pre.53"
   },
+  "resolutions": {
+    "@lambdacurry/medusa-product-reviews/zod": "4.2.0"
+  },
   "installConfig": {
     "hoistingLimits": "workspaces"
   },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@medusajs/workflow-engine-inmemory": "2.17.1",
     "@medusajs/workflow-engine-redis": "2.17.1",
     "@medusajs/workflows-sdk": "2.17.1",
-    "zod": "4.4.3",
+    "@lambdacurry/medusa-product-reviews/zod": "4.2.0",
     "react-hook-form": "7.55.0",
     "react": "19.2.7",
     "react-dom": "19.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28777,10 +28777,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod@npm:4.2.0":
+  version: 4.2.0
+  resolution: "zod@npm:4.2.0"
+  checksum: 10c0/c9fa563f4866f5554c84728f69fe01979d5ab41a104176a4b9f1a182fa670b6e55ffe1be81863dc03d8b36c90ee9e917353b429f4aa3615b5f63dc4c8d5d92d3
+  languageName: node
+  linkType: hard
+
 "zod@npm:4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- remove the global Zod 4 resolution so Medusa plugins can use their declared Zod version
- keep storefront on its direct zod@4.4.3 dependency while @medusajs packages resolve zod@4.2.0 and the reviews plugin resolves zod@3.25.76

## Verification
- corepack yarn install
- corepack yarn why zod
- corepack yarn workspace medusa typecheck
- corepack yarn workspace storefront typecheck
- docker build -f apps/medusa/Dockerfile .